### PR TITLE
fix: release PAT, remove comments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: release
         uses: cycjimmy/semantic-release-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         with:
           extra_plugins: |
             conventional-changelog-conventionalcommits
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: wangyoucao577/go-release-action@v1.28
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.AUTOMATION_PAT }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: 1.18

--- a/provider/pkg/provider/eks.go
+++ b/provider/pkg/provider/eks.go
@@ -14,7 +14,6 @@ import (
 
 // EksArgs supplies input for configuring EKS
 type EksArgs struct {
-	// TODO document options, add pulumi tags
 	// Optional, name of the EKS cluster. Default: <stack name>
 	ClusterName string `pulumi:"clusterName"`
 	// Optional, k8s version of the EKS cluster. Default: 1.22.6


### PR DESCRIPTION
the built-in github token is causing failure due to branch protection. this wasn't an issue before because the settings bot was being slow to update, so branch protection wasn't enabled.

also remove a comment in the provider code to trigger a release.