### PR TITLE
fix: add eks kubeconfig generation

### DIFF
--- a/provider/pkg/provider/eks_kubeconfig.go
+++ b/provider/pkg/provider/eks_kubeconfig.go
@@ -1,0 +1,38 @@
+package provider
+
+// this thing is so ugly, put it in it's own file
+var eksDefaultKubeConfig string = `apiVersion: v1
+clusters:
+- cluster:
+    server: %s
+    certificate-authority-data: %s
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: aws
+  name: aws
+current-context: aws
+kind: Config
+preferences: {}
+users:
+- name: aws
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: aws
+      args:
+      - "eks"
+      - "get-token"
+      - "--cluster-name"
+      - "%s"
+`
+
+var kubeConfigArgsRoleArn string = `      - "--role-arn"
+      - "%s"
+`
+
+var kubeConfigArgsAwsProfile string = `      env:
+      - name: AWS_PROFILE
+        value: "%s"
+`

--- a/schema.yaml
+++ b/schema.yaml
@@ -520,9 +520,28 @@ resources:
           type: string
         description: >-
           Required, list of subnet IDs to deploy the cluster and nodegroups to
+      kubeConfigAssumeRoleArn:
+        type: string
+        description: >-
+          Optional, assume role arn to add to the kubeconfig.
+      kubeConfigAwsProfile:
+        type: string
+        description: >-
+          Optional, AWS profile to add to the kubeconfig.
     requiredInputs:
       - subnetIDs
       - nodeGroupConfig
+    properties:
+      cluster:
+        "$ref": "/aws/v5.3.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
+      oidcProvider:
+        "$ref": "/aws/v5.3.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
+      kubeConfig:
+        type: string
+    required:
+      - cluster
+      - oidcProvider
+      - kubeConfig
   catalystsquad-platform:index:ArgocdApp:
     isComponent: true
     inputProperties:

--- a/sdk/dotnet/Eks.cs
+++ b/sdk/dotnet/Eks.cs
@@ -12,6 +12,16 @@ namespace Pulumi.CatalystsquadPlatform
     [CatalystsquadPlatformResourceType("catalystsquad-platform:index:Eks")]
     public partial class Eks : Pulumi.ComponentResource
     {
+        [Output("cluster")]
+        public Output<Pulumi.Aws.Eks.Cluster> Cluster { get; private set; } = null!;
+
+        [Output("kubeConfig")]
+        public Output<string> KubeConfig { get; private set; } = null!;
+
+        [Output("oidcProvider")]
+        public Output<Pulumi.Aws.Iam.OpenIdConnectProvider> OidcProvider { get; private set; } = null!;
+
+
         /// <summary>
         /// Create a Eks resource with the given unique name, arguments, and options.
         /// </summary>
@@ -81,6 +91,18 @@ namespace Pulumi.CatalystsquadPlatform
         /// </summary>
         [Input("k8sVersion")]
         public Input<string>? K8sVersion { get; set; }
+
+        /// <summary>
+        /// Optional, assume role arn to add to the kubeconfig.
+        /// </summary>
+        [Input("kubeConfigAssumeRoleArn")]
+        public Input<string>? KubeConfigAssumeRoleArn { get; set; }
+
+        /// <summary>
+        /// Optional, AWS profile to add to the kubeconfig.
+        /// </summary>
+        [Input("kubeConfigAwsProfile")]
+        public Input<string>? KubeConfigAwsProfile { get; set; }
 
         [Input("nodeGroupConfig", required: true)]
         private InputList<Inputs.EksNodeGroupArgs>? _nodeGroupConfig;

--- a/sdk/go/catalystsquad-platform/eks.go
+++ b/sdk/go/catalystsquad-platform/eks.go
@@ -8,11 +8,17 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/eks"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 type Eks struct {
 	pulumi.ResourceState
+
+	Cluster      eks.ClusterOutput               `pulumi:"cluster"`
+	KubeConfig   pulumi.StringOutput             `pulumi:"kubeConfig"`
+	OidcProvider iam.OpenIdConnectProviderOutput `pulumi:"oidcProvider"`
 }
 
 // NewEks registers a new resource with the given unique name, arguments, and options.
@@ -52,6 +58,10 @@ type eksArgs struct {
 	EnabledClusterLogTypes *string `pulumi:"enabledClusterLogTypes"`
 	// Optional, k8s version of the EKS cluster. Default: 1.22.6
 	K8sVersion *string `pulumi:"k8sVersion"`
+	// Optional, assume role arn to add to the kubeconfig.
+	KubeConfigAssumeRoleArn *string `pulumi:"kubeConfigAssumeRoleArn"`
+	// Optional, AWS profile to add to the kubeconfig.
+	KubeConfigAwsProfile *string `pulumi:"kubeConfigAwsProfile"`
 	// Required, list of nodegroup configurations to create.
 	NodeGroupConfig []EksNodeGroup `pulumi:"nodeGroupConfig"`
 	// Optional, k8s version of all node groups. Allows for upgrading the control plane before upgrading nodegroups. Default: <k8sVersion>
@@ -76,6 +86,10 @@ type EksArgs struct {
 	EnabledClusterLogTypes pulumi.StringPtrInput
 	// Optional, k8s version of the EKS cluster. Default: 1.22.6
 	K8sVersion pulumi.StringPtrInput
+	// Optional, assume role arn to add to the kubeconfig.
+	KubeConfigAssumeRoleArn pulumi.StringPtrInput
+	// Optional, AWS profile to add to the kubeconfig.
+	KubeConfigAwsProfile pulumi.StringPtrInput
 	// Required, list of nodegroup configurations to create.
 	NodeGroupConfig EksNodeGroupArrayInput
 	// Optional, k8s version of all node groups. Allows for upgrading the control plane before upgrading nodegroups. Default: <k8sVersion>

--- a/sdk/nodejs/eks.ts
+++ b/sdk/nodejs/eks.ts
@@ -5,6 +5,8 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "./types";
 import * as utilities from "./utilities";
 
+import * as pulumiAws from "@pulumi/aws";
+
 export class Eks extends pulumi.ComponentResource {
     /** @internal */
     public static readonly __pulumiType = 'catalystsquad-platform:index:Eks';
@@ -20,6 +22,9 @@ export class Eks extends pulumi.ComponentResource {
         return obj['__pulumiType'] === Eks.__pulumiType;
     }
 
+    public /*out*/ readonly cluster!: pulumi.Output<pulumiAws.eks.Cluster>;
+    public /*out*/ readonly kubeConfig!: pulumi.Output<string>;
+    public /*out*/ readonly oidcProvider!: pulumi.Output<pulumiAws.iam.OpenIdConnectProvider>;
 
     /**
      * Create a Eks resource with the given unique name, arguments, and options.
@@ -45,10 +50,18 @@ export class Eks extends pulumi.ComponentResource {
             resourceInputs["enableECRAccess"] = args ? args.enableECRAccess : undefined;
             resourceInputs["enabledClusterLogTypes"] = args ? args.enabledClusterLogTypes : undefined;
             resourceInputs["k8sVersion"] = args ? args.k8sVersion : undefined;
+            resourceInputs["kubeConfigAssumeRoleArn"] = args ? args.kubeConfigAssumeRoleArn : undefined;
+            resourceInputs["kubeConfigAwsProfile"] = args ? args.kubeConfigAwsProfile : undefined;
             resourceInputs["nodeGroupConfig"] = args ? args.nodeGroupConfig : undefined;
             resourceInputs["nodeGroupVersion"] = args ? args.nodeGroupVersion : undefined;
             resourceInputs["subnetIDs"] = args ? args.subnetIDs : undefined;
+            resourceInputs["cluster"] = undefined /*out*/;
+            resourceInputs["kubeConfig"] = undefined /*out*/;
+            resourceInputs["oidcProvider"] = undefined /*out*/;
         } else {
+            resourceInputs["cluster"] = undefined /*out*/;
+            resourceInputs["kubeConfig"] = undefined /*out*/;
+            resourceInputs["oidcProvider"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Eks.__pulumiType, name, resourceInputs, opts, true /*remote*/);
@@ -87,6 +100,14 @@ export interface EksArgs {
      * Optional, k8s version of the EKS cluster. Default: 1.22.6
      */
     k8sVersion?: pulumi.Input<string>;
+    /**
+     * Optional, assume role arn to add to the kubeconfig.
+     */
+    kubeConfigAssumeRoleArn?: pulumi.Input<string>;
+    /**
+     * Optional, AWS profile to add to the kubeconfig.
+     */
+    kubeConfigAwsProfile?: pulumi.Input<string>;
     /**
      * Required, list of nodegroup configurations to create.
      */

--- a/sdk/python/pulumi_catalystsquad_platform/eks.py
+++ b/sdk/python/pulumi_catalystsquad_platform/eks.py
@@ -8,6 +8,7 @@ import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
 from . import _utilities
 from ._inputs import *
+import pulumi_aws
 
 __all__ = ['EksArgs', 'Eks']
 
@@ -23,6 +24,8 @@ class EksArgs:
                  enable_ecr_access: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[str]] = None,
                  k8s_version: Optional[pulumi.Input[str]] = None,
+                 kube_config_assume_role_arn: Optional[pulumi.Input[str]] = None,
+                 kube_config_aws_profile: Optional[pulumi.Input[str]] = None,
                  node_group_version: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Eks resource.
@@ -35,6 +38,8 @@ class EksArgs:
         :param pulumi.Input[bool] enable_ecr_access: Optional, whether to enable ECR access policy on nodegroups. Default: true
         :param pulumi.Input[str] enabled_cluster_log_types: Optional, list of log types to enable on the cluster. Default: []
         :param pulumi.Input[str] k8s_version: Optional, k8s version of the EKS cluster. Default: 1.22.6
+        :param pulumi.Input[str] kube_config_assume_role_arn: Optional, assume role arn to add to the kubeconfig.
+        :param pulumi.Input[str] kube_config_aws_profile: Optional, AWS profile to add to the kubeconfig.
         :param pulumi.Input[str] node_group_version: Optional, k8s version of all node groups. Allows for upgrading the control plane before upgrading nodegroups. Default: <k8sVersion>
         """
         pulumi.set(__self__, "node_group_config", node_group_config)
@@ -53,6 +58,10 @@ class EksArgs:
             pulumi.set(__self__, "enabled_cluster_log_types", enabled_cluster_log_types)
         if k8s_version is not None:
             pulumi.set(__self__, "k8s_version", k8s_version)
+        if kube_config_assume_role_arn is not None:
+            pulumi.set(__self__, "kube_config_assume_role_arn", kube_config_assume_role_arn)
+        if kube_config_aws_profile is not None:
+            pulumi.set(__self__, "kube_config_aws_profile", kube_config_aws_profile)
         if node_group_version is not None:
             pulumi.set(__self__, "node_group_version", node_group_version)
 
@@ -165,6 +174,30 @@ class EksArgs:
         pulumi.set(self, "k8s_version", value)
 
     @property
+    @pulumi.getter(name="kubeConfigAssumeRoleArn")
+    def kube_config_assume_role_arn(self) -> Optional[pulumi.Input[str]]:
+        """
+        Optional, assume role arn to add to the kubeconfig.
+        """
+        return pulumi.get(self, "kube_config_assume_role_arn")
+
+    @kube_config_assume_role_arn.setter
+    def kube_config_assume_role_arn(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "kube_config_assume_role_arn", value)
+
+    @property
+    @pulumi.getter(name="kubeConfigAwsProfile")
+    def kube_config_aws_profile(self) -> Optional[pulumi.Input[str]]:
+        """
+        Optional, AWS profile to add to the kubeconfig.
+        """
+        return pulumi.get(self, "kube_config_aws_profile")
+
+    @kube_config_aws_profile.setter
+    def kube_config_aws_profile(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "kube_config_aws_profile", value)
+
+    @property
     @pulumi.getter(name="nodeGroupVersion")
     def node_group_version(self) -> Optional[pulumi.Input[str]]:
         """
@@ -189,6 +222,8 @@ class Eks(pulumi.ComponentResource):
                  enable_ecr_access: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[str]] = None,
                  k8s_version: Optional[pulumi.Input[str]] = None,
+                 kube_config_assume_role_arn: Optional[pulumi.Input[str]] = None,
+                 kube_config_aws_profile: Optional[pulumi.Input[str]] = None,
                  node_group_config: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EksNodeGroupArgs']]]]] = None,
                  node_group_version: Optional[pulumi.Input[str]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -204,6 +239,8 @@ class Eks(pulumi.ComponentResource):
         :param pulumi.Input[bool] enable_ecr_access: Optional, whether to enable ECR access policy on nodegroups. Default: true
         :param pulumi.Input[str] enabled_cluster_log_types: Optional, list of log types to enable on the cluster. Default: []
         :param pulumi.Input[str] k8s_version: Optional, k8s version of the EKS cluster. Default: 1.22.6
+        :param pulumi.Input[str] kube_config_assume_role_arn: Optional, assume role arn to add to the kubeconfig.
+        :param pulumi.Input[str] kube_config_aws_profile: Optional, AWS profile to add to the kubeconfig.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EksNodeGroupArgs']]]] node_group_config: Required, list of nodegroup configurations to create.
         :param pulumi.Input[str] node_group_version: Optional, k8s version of all node groups. Allows for upgrading the control plane before upgrading nodegroups. Default: <k8sVersion>
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: Required, list of subnet IDs to deploy the cluster and nodegroups to
@@ -238,6 +275,8 @@ class Eks(pulumi.ComponentResource):
                  enable_ecr_access: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[str]] = None,
                  k8s_version: Optional[pulumi.Input[str]] = None,
+                 kube_config_assume_role_arn: Optional[pulumi.Input[str]] = None,
+                 kube_config_aws_profile: Optional[pulumi.Input[str]] = None,
                  node_group_config: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EksNodeGroupArgs']]]]] = None,
                  node_group_version: Optional[pulumi.Input[str]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -264,6 +303,8 @@ class Eks(pulumi.ComponentResource):
             __props__.__dict__["enable_ecr_access"] = enable_ecr_access
             __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
             __props__.__dict__["k8s_version"] = k8s_version
+            __props__.__dict__["kube_config_assume_role_arn"] = kube_config_assume_role_arn
+            __props__.__dict__["kube_config_aws_profile"] = kube_config_aws_profile
             if node_group_config is None and not opts.urn:
                 raise TypeError("Missing required property 'node_group_config'")
             __props__.__dict__["node_group_config"] = node_group_config
@@ -271,10 +312,28 @@ class Eks(pulumi.ComponentResource):
             if subnet_ids is None and not opts.urn:
                 raise TypeError("Missing required property 'subnet_ids'")
             __props__.__dict__["subnet_ids"] = subnet_ids
+            __props__.__dict__["cluster"] = None
+            __props__.__dict__["kube_config"] = None
+            __props__.__dict__["oidc_provider"] = None
         super(Eks, __self__).__init__(
             'catalystsquad-platform:index:Eks',
             resource_name,
             __props__,
             opts,
             remote=True)
+
+    @property
+    @pulumi.getter
+    def cluster(self) -> pulumi.Output['pulumi_aws.eks.Cluster']:
+        return pulumi.get(self, "cluster")
+
+    @property
+    @pulumi.getter(name="kubeConfig")
+    def kube_config(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "kube_config")
+
+    @property
+    @pulumi.getter(name="oidcProvider")
+    def oidc_provider(self) -> pulumi.Output['pulumi_aws.iam.OpenIdConnectProvider']:
+        return pulumi.get(self, "oidc_provider")
 


### PR DESCRIPTION
so that all components can be created in the same stack without
requiring an intermediate `aws eks update-kubeconfig`

add output properties to eks cluster component

also rename eksCluster output to just cluster because it was redundant.